### PR TITLE
Maybe add encrypted field [ch8385]

### DIFF
--- a/lib/tracking/tracking.ex
+++ b/lib/tracking/tracking.ex
@@ -43,11 +43,22 @@ defmodule ExAudit.Tracking do
             patch: patch,
             action: action
           }
+          |> maybe_add_encrypted_patch()
 
           [params]
       end
     else
       []
+    end
+  end
+
+  defp maybe_add_encrypted_patch(params) do
+    version_schema = Application.get_env(:ex_audit, :version_schema)
+
+    if Enum.any?(version_schema.__schema__(:fields), & &1 == :encrypted_patch) do
+      Map.put_new(params, :encrypted_patch, params[:patch])
+    else
+      params
     end
   end
 


### PR DESCRIPTION
To encrypt audit (or anything else that already is in production), we need to create a temporary field in the database and save the data we want encrypted to both fields. Example: If User has a field `name` I want encrypted, I would create a temp field `encrypted_name`, and save the user name to both fields.

I was doing this with changeset, like this:
```
  def changeset(struct, attrs \\ %{}) do
    struct
    |> cast(attrs, [:name])
    |> put_encrypted_fields()
  end

  defp put_encrypted_fields(changeset) do
    changeset
    |> put_change(:encrypted_name, get_field(changeset, :name))
  end
```

The audit changeset (https://github.com/goaero/ex_audit#versionex) is actually never called, even though it's documented. Therefore any attempts of copying the patch to the encrypted_patch were unsuccessful.

I see no other easy solution but to edit the lib itself. Any other ideas about how to do this, please ping me.